### PR TITLE
Fix removal of posts in "Explore" page and replace DOMNodeInserted with MutationObserver

### DIFF
--- a/unscroll.js
+++ b/unscroll.js
@@ -39,15 +39,26 @@ var remExplores = () =>  {
   }
 }
 
-var onPageUpdate = () => {
+function onPageUpdate() {
   remReels();
   remExplores();
 }
 
+const observer = new MutationObserver((mutationsList) => {
+  for (const mutation of mutationsList) {
+    if (mutation.type === 'childList') {
+      onPageUpdate();
+    }
+  }
+});
+
+observer.observe(document.body, {
+  childList: true,
+  subtree: true
+});
+
 // Gestionnaire d'événements pour ajuster la position lors du défilement
 document.addEventListener('scroll', adjustScrollPosition);
-document.addEventListener('DOMNodeInserted', remReels);
-document.addEventListener('DOMNodeInserted', remExplores);
 onPageUpdate();
 
 console.log("Unscroll active")

--- a/unscroll.js
+++ b/unscroll.js
@@ -3,7 +3,7 @@ var reels_element = null
 
 var adjustScrollPosition = () => {
     var imageElement = document.querySelector('img[src="/images/instagram/xig/web/illo-confirm-refresh-light.png"]');
-    endread_element = imageElement.parentElement.parentElement;
+    endread_element = imageElement?.parentElement?.parentElement;
     if(!endread_element) {
     	return;
     }
@@ -16,9 +16,9 @@ var adjustScrollPosition = () => {
 }
 
 var remReels = () => {
-    reels_element = document.querySelector('a[href="/reels/"]').parentElement;
-    if(reels_element) {
-    	reels_element.remove();
+    reels_link = document.querySelector('a[href="/reels/"]');
+    if(reels_link) {
+    	reels_link.parentElement.remove();
     }
 }
 

--- a/unscroll.js
+++ b/unscroll.js
@@ -23,13 +23,20 @@ var remReels = () => {
 }
 
 var remExplores = () =>  {
-  if (window.location.href === 'https://www.instagram.com/explore/') {
+  if (window.location.pathname === '/explore/') {
+    let postContainer = document.querySelector('main > :not(nav)');
+    if (!!postContainer) {
+      postContainer.remove();
+    }
+
+    // Gardons l'ancien code pour le cas où
     var proposedPosts = document.querySelectorAll('a[href*="/p/"]');
-    if(!proposedPosts) {return}
-    proposedPosts.forEach(function(link) {
+    if(!!proposedPosts) {
+      proposedPosts.forEach(function(link) {
         link.remove();
-    });
-}
+      });
+    }
+  }
 }
 
 var onPageUpdate = () => {


### PR DESCRIPTION
The URL matching for the explore page was not working for me, because it had additional parameters (it ended in `?__pwa=1`, as I installed Instagram as a PWA). I fixed that by using `location.pathName` instead of `location.href`.

I also fixed some missing null checks, and the deprecation warning about the DOMNodeInserted event.